### PR TITLE
adds MaplessReference constructor for using it from voyage references

### DIFF
--- a/src/Mapless/Mapless.class.st
+++ b/src/Mapless/Mapless.class.st
@@ -270,6 +270,17 @@ Mapless class >> isDeprecated [
 	^ false
 ]
 
+{ #category : #testing }
+Mapless class >> isVoyageReference: anObject [
+	"Answers true if anObject has the keys and values of a voyage reference."
+
+	^ anObject isDictionary
+		and: [ anObject size = 3
+				and: [ (anObject includesKey: '__id')
+						and: [ (anObject includesKey: '#instanceOf')
+								and: [ anObject includesKey: '#collection' ] ] ] ]
+]
+
 { #category : #accessing }
 Mapless class >> keysToExclude [
 	"Answers the names of the keys that should be ignored 

--- a/src/Mapless/MaplessReference.class.st
+++ b/src/Mapless/MaplessReference.class.st
@@ -1,3 +1,6 @@
+"
+When a mapless is composed with another mapless it will use a MaplessReference proxy when is read from the database.
+"
 Class {
 	#name : #MaplessReference,
 	#superclass : #Object,
@@ -30,6 +33,27 @@ MaplessReference class >> fromJSONObject: aJsonObject [
 MaplessReference class >> fromJSONString: aJSONString [
 		
 	^ self fromJSONObject: (OrderedJson readFrom: aJSONString readStream) 
+]
+
+{ #category : #actions }
+MaplessReference class >> fromVoyageReference: aDictionaryish [
+	"Answers a MaplessReference based on the voyage reference information found at aDictionaryish.
+	It assumes the Mapless model class to create for the corresponding composed object has the same name as Voyage would expect suffixed with 'Mapless'.
+	Example: if voyage has this object as BlahUser its document would instantiate BlahUserMapless instances."
+
+	| classSelector |
+	classSelector := (aDictionaryish at: '#instanceOf') , 'Mapless'.
+	^ self
+		fromVoyageReference: aDictionaryish
+		classSelector: classSelector
+]
+
+{ #category : #actions }
+MaplessReference class >> fromVoyageReference: aJsonObject classSelector: classSelector [
+	^ self new
+		id: (aJsonObject at: '__id');
+		modelClass: classSelector;
+		yourself
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Example of a lazy accessor using it:

```smalltalk
SomeEquivalentToVoyageRootObjectMapless>>someComposedVoyageObjectProperty
	| value |
	value := self data at: 'someComposedVoyageObjectProperty'.
	value ifNil: [ ^ nil ].
	^ (self class isVoyageReference: value)
		ifFalse:[ value ]
		ifTrue: [ self data
				at: 'someComposedVoyageObjectProperty'
				put: (MaplessReference fromVoyageReference: value) ]