### PR TITLE
Feature/voyage compatible saves

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+December 6, 2021
+===================================
+* Being less strict about the conditions to answer true on `isVoyageReference: anObject in: aMaplessRepository` and `canRepresentSubMapless: anObject in: aMaplessRepository` in order to make `Mapless` able to interoperate with `Voyage`.
+* Using resolver's help to make `Mapless` and `MaplessReference` to be returned `asStorable:`.
+* `MaplessVoyageWithMaplessSuffixResolver` now uses `referenceAsJsonObject: anObject in: aMaplessRepository` to implement a mapless data object that is compatible with Voyage. Just before a save this method is used by Mapless and now it's being used, beside the usual, including Voyage metadata making both Voyage and Mapless able to achieve interoperability.
+
 November 16, 2021 - v0.4.9-alpha | New Eagle
 ===================================
 * Pushed a re-designed version of `MaplessMongoReplicaSetPool`. A `MaplessMongoRepository` now will be resilient to primary node changes.

--- a/src/Mapless-Base-Core/Mapless.class.st
+++ b/src/Mapless-Base-Core/Mapless.class.st
@@ -472,6 +472,11 @@ Mapless >> jsonWriteOn: aStream [
 ]
 
 { #category : #accessing }
+Mapless >> maplessClassName [
+	^ self class maplessClassName
+]
+
+{ #category : #accessing }
 Mapless >> maplessData [
 	"Returns the data part of a Mapless document.
 	By default it is the data object, but subclasses might extend or change this."
@@ -688,7 +693,8 @@ Mapless >> setSubModelReferencesAt: aKey with: anObject in: aMaplessRepository [
 	"2. it's a collection of submodels"
 	(anObject isCollection
 		and: [ anObject notEmpty
-				and: [ anObject anySatisfy: [ :e | aMaplessRepository canRepresentSubMapless: e ] ] ])
+				and: [ anObject
+						anySatisfy: [ :e | aMaplessRepository canRepresentSubMapless: e ] ] ])
 		ifTrue: [ self
 				setReferencesFrom: anObject
 				on: aKey

--- a/src/Mapless-Base-Core/MaplessReference.class.st
+++ b/src/Mapless-Base-Core/MaplessReference.class.st
@@ -51,10 +51,7 @@ MaplessReference >> asJsonObjectIn: aMaplessRepository [
 		ifNil: [ ^ MaplessUnsavedSubmodel
 				signal:
 					'This sub model is unsaved. You need to save all sub mapless before saving a composed mapless' ].
-	^ OrderedJsonObject new
-		at: '_c' put: self maplessClassName;
-		at: repository idPropertyName put: self id;
-		yourself
+	^ aMaplessRepository maplessReferenceAsJsonObject: self
 ]
 
 { #category : #accessing }

--- a/src/Mapless-Base-Core/MaplessRepository.class.st
+++ b/src/Mapless-Base-Core/MaplessRepository.class.st
@@ -61,14 +61,15 @@ MaplessRepository >> asStorable: anObject [
 	^ anObject isCollection
 		ifTrue: [ anObject class = OrderedJsonObject
 				ifTrue: [ (JsonObject fromAssociations: anObject associations)
-						collect: [ :e | self asStorable: e ] ]
+						collect: [ :e | self resolver maplessAsStorable: e in: self ] ]
 				ifFalse: [ anObject collect: [ :e | self asStorable: e ] ] ]
 		ifFalse: [ anObject class = MaplessReference
 				ifFalse: [ (anObject isKindOf: Mapless)
-						ifTrue: [ (anObject asMaplessReferenceIn: self) asJsonObjectIn: self ]
+						ifTrue: [ (resolver asMaplessReferenceIn: anObject in: self)
+								asJsonObjectIn: self ]
 						ifFalse: [ anObject ] ]
 				ifTrue: [ anObject hasModel
-						ifTrue: [ anObject asJsonObjectIn: self ]
+						ifTrue: [ resolver maplessReferenceAsJsonObject: anObject in: self ]
 						ifFalse: [ MaplessUnsavedSubmodel
 								signal:
 									'This sub model is unsaved. You need to save all sub models before saving a composed model' ] ] ]
@@ -187,11 +188,14 @@ MaplessRepository >> maplessClassFor: aJsonObject [
 	^ resolver maplessClassFor: aJsonObject in: self
 ]
 
+{ #category : #accessing }
+MaplessRepository >> maplessReferenceAsJsonObject: aMaplessReference [
+	^ resolver maplessReferenceAsJsonObject: aMaplessReference in: self
+]
+
 { #category : #actions }
 MaplessRepository >> normalizeIdOfOn: aJsonObject [
-	aJsonObject at: 'id' put: (aJsonObject at: self idPropertyName).
-	aJsonObject removeKey: self idPropertyName ifAbsent: [ nil ].
-	^ aJsonObject
+	^ resolver normalizeIdOfOn: aJsonObject in: self
 ]
 
 { #category : #hooks }
@@ -297,19 +301,4 @@ MaplessRepository >> shutDown [
 { #category : #actions }
 MaplessRepository >> startUp: anInteger [
 	accessor start: anInteger
-]
-
-{ #category : #actions }
-MaplessRepository >> storableFor: aJsonObject [
-	"Returns a new JsonObject that's the BSON friendly version of aJsonObject
-	by visinting all the values. It will complain if sub models are not previously saved."
-
-	| storableDocument storablePart |
-	storableDocument := JsonObject new.
-	aJsonObject
-		keysAndValuesDo: [ :key :value | 
-			storablePart := self asStorable: value.
-			key ~= 'id'
-				ifTrue: [ storableDocument at: key put: storablePart ] ].
-	^ storableDocument
 ]

--- a/src/Mapless-Base-Core/MaplessResolver.class.st
+++ b/src/Mapless-Base-Core/MaplessResolver.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Mapless-Base-Core-Resolvers'
 }
 
+{ #category : #converting }
+MaplessResolver >> asMaplessReferenceIn: anObject in: aMaplessRepository [
+	^ MaplessReference for: anObject in: aMaplessRepository
+]
+
 { #category : #testing }
 MaplessResolver >> canRepresentArrayOfMaplessReferences: anObject in: aMaplessRepository [
 	"Answers true if anObject can represent a collection of sub mapless references."
@@ -26,6 +31,11 @@ MaplessResolver >> canRepresentSubMapless: anObject in: aMaplessRepository [
 				and: [ (anObject includesKey: '_id') and: [ anObject includesKey: '_c' ] ] ]
 ]
 
+{ #category : #converting }
+MaplessResolver >> maplessAsStorable: aMapless in: aMaplessRepository [
+	^ aMaplessRepository asStorable: aMapless
+]
+
 { #category : #accessing }
 MaplessResolver >> maplessClassFor: aJsonObject in: aMaplessRepository [
 	| className |
@@ -43,10 +53,50 @@ MaplessResolver >> maplessClassNameFor: aJsonObject in: aMaplessRepository [
 	^ aJsonObject at: '_c'
 ]
 
+{ #category : #converting }
+MaplessResolver >> maplessReferenceAsJsonObject: aMaplessReference in: aMaplessRepository [
+	^ OrderedJsonObject new
+		at: '_c' put: aMaplessReference maplessClassName;
+		at: aMaplessRepository idPropertyName put: aMaplessReference id;
+		yourself
+]
+
+{ #category : #actions }
+MaplessResolver >> normalizeIdOfOn: aJsonObject in: aMaplessRepository [
+	aJsonObject
+		at: 'id'
+		put: (aJsonObject at: aMaplessRepository idPropertyName).
+	aJsonObject
+		removeKey: aMaplessRepository idPropertyName
+		ifAbsent: [ nil ].
+	^ aJsonObject
+]
+
+{ #category : #hooks }
+MaplessResolver >> onBeforeSave: aMapless [
+	"no-op"
+]
+
 { #category : #accessing }
 MaplessResolver >> referenceDataFrom: aJsonObject in: aMaplessRepository [
 	^ JsonObject new
 		at: aMaplessRepository idPropertyName put: aJsonObject _id;
 		at: '_c' put: (aJsonObject at: '_c');
 		yourself
+]
+
+{ #category : #converting }
+MaplessResolver >> storableFor: aMapless in: aMaplessRepository [
+	"Returns a new JsonObject that's the BSON friendly version of the jsonObject of aMapless.
+	It does that by visiting to cast all the values. 
+	It will complain if sub models are not previously saved."
+
+	| storableDocument storablePart |
+	storableDocument := JsonObject new.
+	aMapless maplessData
+		keysAndValuesDo: [ :key :value | 
+			storablePart := aMaplessRepository asStorable: value.
+			key ~= 'id'
+				ifTrue: [ storableDocument at: key put: storablePart ] ].
+	^ storableDocument
 ]

--- a/src/Mapless-Base-Core/MaplessVoyageWithMaplessSuffixResolver.class.st
+++ b/src/Mapless-Base-Core/MaplessVoyageWithMaplessSuffixResolver.class.st
@@ -14,8 +14,19 @@ Class {
 MaplessVoyageWithMaplessSuffixResolver >> canRepresentSubMapless: anObject in: aMaplessRepository [
 	"Answers true if anObject can represent a sub mapless."
 
-	^ (super canRepresentSubMapless: anObject in: aMaplessRepository)
+	^ (anObject isDictionary
+		and: [ (anObject includesKey: '_id') and: [ anObject includesKey: '_c' ] ])
 		or: [ self isVoyageReference: anObject in: aMaplessRepository ]
+]
+
+{ #category : #converting }
+MaplessVoyageWithMaplessSuffixResolver >> ensureVoyageMetadataIn: storableDocument for: aMapless in: aMaplessRepository [
+	"Makes sure aMapless has the metadata that would be expected by Voyage."
+
+	storableDocument
+		at: '_id' put: aMapless id;
+		at: '#instanceOf' put: (self voyageClassNameFrom: aMapless);
+		yourself
 ]
 
 { #category : #testing }
@@ -35,17 +46,67 @@ MaplessVoyageWithMaplessSuffixResolver >> isVoyageReference: anObject in: aMaple
 	"Answers true if anObject has the keys and values of a voyage reference."
 
 	^ anObject isDictionary
-		and: [ anObject size = 3
-				and: [ (anObject includesKey: '__id')
-						and: [ (anObject includesKey: '#instanceOf')
-								and: [ anObject includesKey: '#collection' ] ] ] ]
+		and: [ (anObject includesKey: '__id')
+				and: [ (anObject includesKey: '#instanceOf')
+						and: [ anObject includesKey: '#collection' ] ] ]
+]
+
+{ #category : #converting }
+MaplessVoyageWithMaplessSuffixResolver >> maplessAsStorable: aMapless in: aMaplessRepository [
+	aMapless maplessData
+		at: '_id' put: aMapless id;
+		at: '#instanceOf' put: aMapless class maplessClassName;
+		yourself.
+	^ super maplessAsStorable: aMapless in: aMaplessRepository
+]
+
+{ #category : #accessing }
+MaplessVoyageWithMaplessSuffixResolver >> maplessClassFor: aJsonObject in: aMaplessRepository [
+	| className |
+	className := self
+		maplessClassNameFor: aJsonObject
+		in: aMaplessRepository.
+	^ Smalltalk
+		at: className asSymbol
+		ifAbsent: [ self
+				error: 'The resolver could not find ' , className , ' in this image.' ]
 ]
 
 { #category : #accessing }
 MaplessVoyageWithMaplessSuffixResolver >> maplessClassNameFor: aJsonObject in: aMaplessRepository [
 	^ (self isVoyage: aJsonObject in: aMaplessRepository)
-		ifTrue: [ (aJsonObject at: '#instanceOf') , suffix ]
+		ifTrue: [ self maplessClassNameFromVoyageReference: aJsonObject ]
 		ifFalse: [ aJsonObject at: '_c' ]
+]
+
+{ #category : #accessing }
+MaplessVoyageWithMaplessSuffixResolver >> maplessClassNameFromVoyageReference: aJsonObject [
+	^ (aJsonObject at: '#instanceOf') , suffix
+]
+
+{ #category : #converting }
+MaplessVoyageWithMaplessSuffixResolver >> maplessReferenceAsJsonObject: aMaplessReference in: aMaplessRepository [
+	^ (super
+		maplessReferenceAsJsonObject: aMaplessReference
+		in: aMaplessRepository)
+		at: '__id' put: aMaplessReference id;
+		at: '#instanceOf' put: (self voyageClassNameFrom: aMaplessReference);
+		at: '#collection' put: (self voyageCollectionNameFrom: aMaplessReference);
+		yourself
+]
+
+{ #category : #converting }
+MaplessVoyageWithMaplessSuffixResolver >> noasMaplessReferenceIn: aMapless in: aMaplessRepository [
+	| reference |
+	reference := super
+		asMaplessReferenceIn: aMapless
+		in: aMaplessRepository.
+	reference data
+		at: '__id' put: aMapless id;
+		at: '#instanceOf' put: (self voyageClassNameFrom: aMapless);
+		at: '#collection' put: (self voyageCollectionNameFrom: aMapless);
+		yourself.
+	^ reference
 ]
 
 { #category : #accessing }
@@ -55,9 +116,26 @@ MaplessVoyageWithMaplessSuffixResolver >> referenceDataFrom: aJsonObject in: aMa
 		in: aMaplessRepository)
 		ifTrue: [ JsonObject new
 				at: aMaplessRepository idPropertyName put: aJsonObject __id;
-				at: '_c' put: (aJsonObject at: '#instanceOf') , suffix;
+				at: '_c' put: (self maplessClassNameFromVoyageReference: aJsonObject);
 				yourself ]
 		ifFalse: [ aJsonObject ]
+]
+
+{ #category : #converting }
+MaplessVoyageWithMaplessSuffixResolver >> storableFor: aMapless in: aMaplessRepository [
+	"Returns a new JsonObject that's the BSON friendly version of the jsonObject of aMapless.
+	It does that by visiting to cast all the values. 
+	It will complain if sub models are not previously saved."
+
+	| storableDocument |
+	storableDocument := super
+		storableFor: aMapless
+		in: aMaplessRepository.
+	self
+		ensureVoyageMetadataIn: storableDocument
+		for: aMapless
+		in: aMaplessRepository.
+	^ storableDocument
 ]
 
 { #category : #accessing }
@@ -68,4 +146,17 @@ MaplessVoyageWithMaplessSuffixResolver >> suffix [
 { #category : #accessing }
 MaplessVoyageWithMaplessSuffixResolver >> suffix: anObject [
 	suffix := anObject
+]
+
+{ #category : #accessing }
+MaplessVoyageWithMaplessSuffixResolver >> voyageClassNameFrom: aMaplessOrMaplessReference [
+	| className where |
+	className := aMaplessOrMaplessReference maplessClassName.
+	where := className findString: suffix.
+	^ className copyFrom: 1 to: where - 1
+]
+
+{ #category : #accessing }
+MaplessVoyageWithMaplessSuffixResolver >> voyageCollectionNameFrom: aMapless [
+	^ self voyageClassNameFrom: aMapless
 ]

--- a/src/Mapless-Mongo-Core/MaplessMongoRepository.class.st
+++ b/src/Mapless-Mongo-Core/MaplessMongoRepository.class.st
@@ -125,15 +125,14 @@ MaplessMongoRepository >> destroy: aMapless [
 MaplessMongoRepository >> destroy: aMapless writeConcern: aConcernOrNil [
 	"Removes aMapless from the persistent collection"
 
-	| bsonFriendly filter |
+	| filter |
 	self onBeforeDestroy: aMapless.
 	filter := JsonObject new
 		at: self idPropertyName put: aMapless id;
 		yourself.
-	bsonFriendly := self storableFor: filter.
 	self
 		readWriteDo: [ (self databaseCollectionNamed: aMapless class collectionName)
-				commandDelete: bsonFriendly
+				commandDelete: filter
 				limit: 1
 				writeConcern: aConcernOrNil ].
 	self onAfterDestroy: aMapless
@@ -336,7 +335,7 @@ MaplessMongoRepository >> insert: aMapless [
 MaplessMongoRepository >> insert: aMapless writeConcern: aConcernOrNil [
 	| bsonFriendly |
 	self onBeforeInsert: aMapless.
-	bsonFriendly := self storableFor: aMapless maplessData.
+	bsonFriendly := resolver storableFor: aMapless in: self.
 	self
 		readWriteDo: [ (self databaseCollectionNamed: aMapless class collectionName)
 				commandInsert: bsonFriendly
@@ -463,7 +462,7 @@ MaplessMongoRepository >> upsert: aMapless [
 MaplessMongoRepository >> upsert: aMapless writeConcern: aConcernOrNil [
 	| bsonFriendly |
 	self onBeforeUpsert: aMapless.
-	bsonFriendly := self storableFor: aMapless maplessData.
+	bsonFriendly := resolver storableFor: aMapless in: self.
 	self
 		readWriteDo: [ self database
 				commandUpsert:

--- a/src/Mapless-Mongo-Tests/MaplessVoyageMongoModelTest.class.st
+++ b/src/Mapless-Mongo-Tests/MaplessVoyageMongoModelTest.class.st
@@ -21,7 +21,7 @@ MaplessVoyageMongoModelTest >> setUp [
 	repository
 		resolver:
 			(MaplessVoyageWithMaplessSuffixResolver new
-				suffix: 'Imported';
+				suffix: 'Interoperating';
 				yourself)
 ]
 
@@ -34,12 +34,84 @@ MaplessVoyageMongoModelTest >> tearDown [
 ]
 
 { #category : #tests }
-MaplessVoyageMongoModelTest >> testReifyWitVoyageMetadata [
-	| serializedFromVoyage |
-	serializedFromVoyage := '{"__id": "abc123", "#instanceOf": "DummyPerson","#collection": "DummyPerson"}'.
+MaplessVoyageMongoModelTest >> testReifyWithReferenceFromVoyageMetadata [
+	| serializedFromVoyage deserializedFromVoyage |
+	serializedFromVoyage := '{"_id": "596f7169a5aa73b9a2110def", "#instanceOf": "DummyUser","#version":345,"username":"Paul","person":{"__id": "d9b4e739421aa92bd8002411","#collection": "DummyPerson","#instanceOf": "DummyPerson"}}'.
+	deserializedFromVoyage := Mapless
+		fromJSONString: serializedFromVoyage
+		in: repository.
 	self
-		assert:
-			(DummyPerson fromJSONString: serializedFromVoyage in: repository)
-				class
-		equals: DummyPersonImported
+		assert: deserializedFromVoyage class
+		equals: DummyUserInteroperating.
+	self assert: deserializedFromVoyage username equals: 'Paul'.
+	self assert: deserializedFromVoyage person notNil.
+	self assert: deserializedFromVoyage person class notNil.
+	self
+		assert: deserializedFromVoyage person class
+		equals: MaplessReference
+]
+
+{ #category : #tests }
+MaplessVoyageMongoModelTest >> testSaveWithVoyageMetadata [
+	| found voyageDummyUserJSON voyageDummyPersonJSON personFromMapless userFromMapless command filter cursor |
+	voyageDummyUserJSON := '{"_id": "596f7169a5aa73b9a2110def", "#instanceOf": "DummyUser","#version":345,"username":"Paul","person":{"__id": "d9b4e739421aa92bd8002411","#collection": "DummyPerson","#instanceOf": "DummyPerson"}}'.
+	voyageDummyPersonJSON := '{"_id": "d9b4e739421aa92bd8002411", "#instanceOf": "DummyPerson","#version":345,"firstName":"Buddy"}'.
+	personFromMapless := DummyPersonInteroperating new
+		firstName: 'Buddy';
+		yourself.
+	userFromMapless := DummyUserInteroperating new
+		username: 'buddy';
+		person: personFromMapless;
+		yourself.
+	repository save: personFromMapless.
+	repository save: userFromMapless.
+	found := repository
+		findOne: DummyPersonInteroperating
+		atId: personFromMapless id.
+	self assert: found notNil.
+	self
+		assert: (found maplessData at: '#instanceOf')
+		equals: 'DummyPerson'.
+	self assert: found id equals: personFromMapless id.
+	found := repository
+		findOne: DummyUserInteroperating
+		atId: userFromMapless id.
+	self assert: found notNil.
+	self
+		assert: (found maplessData at: '#instanceOf')
+		equals: 'DummyUser'.
+	self assert: found id equals: userFromMapless id.
+	self assert: found person class equals: MaplessReference.
+	self
+		assert: found person model class
+		equals: DummyPersonInteroperating.
+	self assert: found person id notNil.
+	self assert: found person id equals: personFromMapless id.
+	self assert: found person model notNil.
+	self assert: found person data notNil.
+	filter := Dictionary
+		newFromPairs:
+			{'_id'.
+			userFromMapless id}.
+	command := OrderedDictionary new
+		at: 'find' put: DummyUserInteroperating collectionName;
+		at: 'filter' put: filter asMongoQuery;
+		yourself.
+	repository
+		readOnlyDo: [ cursor := repository newCursorFor: command.
+			found := cursor collect: [ :each | each ] ].
+	self assert: found notNil.
+	self assert: found notEmpty.
+	self assert: ((found first at: 'person') includesKey: '__id').
+	self assert: ((found first at: 'person') includesKey: '#instanceOf').
+	self assert: ((found first at: 'person') includesKey: '#collection').
+	self
+		assert: ((found first at: 'person') at: '__id')
+		equals: personFromMapless id.
+	self
+		assert: ((found first at: 'person') at: '#instanceOf')
+		equals: 'DummyPerson'.
+	self
+		assert: ((found first at: 'person') at: '#collection')
+		equals: 'DummyPerson'
 ]

--- a/src/Mapless-Tests-Base/DummyPersonImported.class.st
+++ b/src/Mapless-Tests-Base/DummyPersonImported.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #DummyPersonImported,
-	#superclass : #Mapless,
-	#category : #'Mapless-Tests-Base-Samples'
-}

--- a/src/Mapless-Tests-Base/DummyPersonInteroperating.class.st
+++ b/src/Mapless-Tests-Base/DummyPersonInteroperating.class.st
@@ -1,0 +1,8 @@
+"
+I'm a DummyPerson mapless that is meant to be used interoperating with objects persisted in Voyage.
+"
+Class {
+	#name : #DummyPersonInteroperating,
+	#superclass : #Mapless,
+	#category : #'Mapless-Tests-Base-Samples'
+}

--- a/src/Mapless-Tests-Base/DummyUserInteroperating.class.st
+++ b/src/Mapless-Tests-Base/DummyUserInteroperating.class.st
@@ -1,0 +1,8 @@
+"
+I'm a DummyUser mapless that is meant to be used interoperating with objects persisted in Voyage.
+"
+Class {
+	#name : #DummyUserInteroperating,
+	#superclass : #Mapless,
+	#category : #'Mapless-Tests-Base-Samples'
+}


### PR DESCRIPTION
December 6, 2021
===================================
* Being less strict about the conditions to answer true on `isVoyageReference: anObject in: aMaplessRepository` and `canRepresentSubMapless: anObject in: aMaplessRepository` in order to make `Mapless` able to interoperate with `Voyage`.
* Using resolver's help to make `Mapless` and `MaplessReference` to be returned `asStorable:`.
* `MaplessVoyageWithMaplessSuffixResolver` now uses `referenceAsJsonObject: anObject in: aMaplessRepository` to implement a mapless data object that is compatible with Voyage. Just before a save this method is used by Mapless and now it's being used, beside the usual, including Voyage metadata making both Voyage and Mapless able to achieve interoperability.

