### PR TITLE
Fixes usage of concerns in save:

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+March 4, 2022 | v0.4.11-alpha | Jolly Adjustment
+===================================
+* Fixed usage of concerns in `MaplessMongoRepository>>save:`.
+
 February 14, 2022 | v0.4.10-alpha | Confidential Star
 ===================================
 * Implemented `save` using `insert` and `update` for `MongoDB` after reviewing subperforming benchmark results https://github.com/sebastianconcept/Mapless/issues/69

--- a/src/Mapless-Mongo-Core/MaplessMongoRepository.class.st
+++ b/src/Mapless-Mongo-Core/MaplessMongoRepository.class.st
@@ -410,19 +410,14 @@ MaplessMongoRepository >> readWriteDo: aBlock with: aDatabaseAccessor [
 MaplessMongoRepository >> save: aMapless [
 	"Storage this instance into the persistent collection"
 
-	self
-		save: aMapless
-		writeConcern: (self upsertConcernFor: aMapless class)
-]
-
-{ #category : #actions }
-MaplessMongoRepository >> save: aMapless writeConcern: aConcernOrNil [
-	"Storage this instance into the persistent collection"
-
 	self onBeforeSave: aMapless.
 	(self isUnsaved: aMapless)
-		ifTrue: [ self insert: aMapless writeConcern: aConcernOrNil ]
-		ifFalse: [ self update: aMapless writeConcern: aConcernOrNil ].
+		ifTrue: [ self
+				insert: aMapless
+				writeConcern: (self insertConcernFor: aMapless class) ]
+		ifFalse: [ self
+				update: aMapless
+				writeConcern: (self updateConcernFor: aMapless class) ].
 	self onAfterSave: aMapless
 ]
 

--- a/src/Mapless-Mongo-Tests/MaplessMongoReplicaSetTest.class.st
+++ b/src/Mapless-Mongo-Tests/MaplessMongoReplicaSetTest.class.st
@@ -36,7 +36,6 @@ MaplessMongoReplicaSetTest >> setConcernsIn: aMaplessMongoRepository [
 	at least one secondary so that if there's a loss of primary the data isn't lost."
 
 	| concern |
-	"Let REST fail in case it can not be written, commit to the journal"
 	concern := MongoWriteConcern new
 		j: true;
 		w: 'majority';


### PR DESCRIPTION
The concerns that where configured to be used in a Mapless class were ignored because `save:` was using the concers setup for `upsert:`.

Now it will either do an `insert:` or `update:` using the right concerns.