### PR TITLE
Add in memory repository support for UnQLite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+April 15, 2022 
+===================================
+* Added `MaplessUnQLiteRepository>>inMemory` methods to make use of RAM based storage offered by UnQLite.
+* Added `testSimpleSaveAndLoadInMemory` for elemental coverage.
+
 April 6, 2022 
 ===================================
 * Removed the docker directory with a replica set docker-compose.yml. This is better done when using your own or https://github.com/sebastianconcept/mongo-rs.

--- a/src/Mapless-Benchmark-Core/MaplessUnQLiteBenchmark.class.st
+++ b/src/Mapless-Benchmark-Core/MaplessUnQLiteBenchmark.class.st
@@ -6,6 +6,7 @@ Class {
 
 { #category : #actions }
 MaplessUnQLiteBenchmark class >> runOn: aMaplessRepository [
+	self save: 1 peopleOn: aMaplessRepository printingOn: NullStream new.
 	self runOn: aMaplessRepository printingOn: Stdio stdout
 ]
 

--- a/src/Mapless-UnQLite-Core/MaplessUnQLiteClient.class.st
+++ b/src/Mapless-UnQLite-Core/MaplessUnQLiteClient.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Mapless-UnQLite-Core-Connections'
 }
 
+{ #category : #actions }
+MaplessUnQLiteClient class >> inMemory [
+	^ self on: ':mem:'
+]
+
 { #category : #accessing }
 MaplessUnQLiteClient class >> on: aDatabaseFileName [
 	^ self new
@@ -64,7 +69,9 @@ MaplessUnQLiteClient >> includesKey: key [
 
 { #category : #initialization }
 MaplessUnQLiteClient >> initializeOn: aDatabaseFileName [
-	unqliteClient := PqDatabase open: aDatabaseFileName
+	unqliteClient := aDatabaseFileName = ':mem:'
+		ifTrue: [ PqDatabase openOnMemory ]
+		ifFalse: [ PqDatabase open: aDatabaseFileName ]
 ]
 
 { #category : #testing }

--- a/src/Mapless-UnQLite-Core/MaplessUnQLitePool.class.st
+++ b/src/Mapless-UnQLite-Core/MaplessUnQLitePool.class.st
@@ -20,6 +20,11 @@ MaplessUnQLitePool class >> defaultMaxClients [
 ]
 
 { #category : #'instance creation' }
+MaplessUnQLitePool class >> inMemory [
+	^ self on: ':mem:'
+]
+
+{ #category : #'instance creation' }
 MaplessUnQLitePool class >> local [
 	^ self shouldNotImplement
 ]
@@ -121,7 +126,9 @@ MaplessUnQLitePool >> initializeMaxClients [
 MaplessUnQLitePool >> makeClient [
 	"Returns a new client so it can be (re)used in the pool"
 
-	^ MaplessUnQLiteClient on: self databaseFileName
+	^ databaseFileName = ':mem:'
+		ifTrue: [ MaplessUnQLiteClient inMemory ]
+		ifFalse: [ MaplessUnQLiteClient on: self databaseFileName ]
 ]
 
 { #category : #accessing }

--- a/src/Mapless-UnQLite-Core/MaplessUnQLiteRepository.class.st
+++ b/src/Mapless-UnQLite-Core/MaplessUnQLiteRepository.class.st
@@ -25,6 +25,14 @@ MaplessUnQLiteRepository class >> idPropertyName [
 	^ 'id'
 ]
 
+{ #category : #actions }
+MaplessUnQLiteRepository class >> inMemory [
+	^ self
+		for: nil
+		with: MaplessUnQLitePool inMemory
+		using: MaplessUnQLiteResolver new
+]
+
 { #category : #accessing }
 MaplessUnQLiteRepository class >> maplessDataPropertyName [
 	"Answers'maplessData' as the column name 

--- a/src/Mapless-UnQLite-Tests/MaplessUnQLiteTest.class.st
+++ b/src/Mapless-UnQLite-Tests/MaplessUnQLiteTest.class.st
@@ -589,6 +589,25 @@ MaplessUnQLiteTest >> testSimpleSaveAndLoad [
 ]
 
 { #category : #tests }
+MaplessUnQLiteTest >> testSimpleSaveAndLoadInMemory [
+	| guy loaded memoryRepository |
+	memoryRepository := MaplessUnQLiteRepository inMemory.
+	guy := DummyPerson new
+		firstName: 'john';
+		lastName: 'q';
+		yourself.
+	memoryRepository save: guy.
+	loaded := memoryRepository findOne: DummyPerson atId: guy id.
+	self assert: loaded notNil.
+	loaded modifiedOn: nil.
+	guy modifiedOn: nil.
+	loaded maplessData
+		keysAndValuesDo: [ :k :v | 
+			((loaded data at: k) isKindOf: DateAndTime) not
+				ifTrue: [ self assert: (loaded data at: k) = (guy data at: k) ] ]
+]
+
+{ #category : #tests }
 MaplessUnQLiteTest >> testSimpleSaveAndUpdate [
 	| guy loaded reloaded |
 	guy := DummyPerson new


### PR DESCRIPTION
Adds inMemory creation methods and a test to get that covered.

```Smalltalk
repository := MaplessUnQLiteRepository inMemory.
MaplessUnQLiteBenchmark runOn: repository.
```