### PR TITLE
106 load on mongo secondaries are not balanced

### DIFF
--- a/src/Mapless-Base-Core/MaplessResourcePolicy.class.st
+++ b/src/Mapless-Base-Core/MaplessResourcePolicy.class.st
@@ -1,0 +1,8 @@
+"
+I'm the abstract class of helpers that are dedicated to allocate resources.
+"
+Class {
+	#name : #MaplessResourcePolicy,
+	#superclass : #Object,
+	#category : #'Mapless-Base-Core-Resources'
+}

--- a/src/Mapless-Base-Core/MaplessResourcesTest.class.st
+++ b/src/Mapless-Base-Core/MaplessResourcesTest.class.st
@@ -76,6 +76,39 @@ MaplessResourcesTest >> test30And70Chance [
 ]
 
 { #category : #tests }
+MaplessResourcesTest >> testEqualChanceWithoutWeightSpecification [
+	| someMongoUrls counters client repeats lowerBound upperBound |
+	someMongoUrls := {'127.0.0.1:27017' . '127.0.0.1:27019'.
+	'127.0.0.1:27020' . '127.0.0.1:27021' . '127.0.0.1:27022'}.
+	counters := Dictionary new.
+	repository := MaplessMongoRepository
+		for: 'Mapless-Test'
+		with:
+			(MaplessMongoReplicaSetPool
+				mongoUrls: someMongoUrls
+				database: 'Mapless-Test').
+	repository accessor
+		minReadOnlyClients: 10;
+		minReadWriteClients: 10;
+		start.
+	someMongoUrls do: [ :url | counters at: url asMongoUrl put: 0 ].
+	counters
+		removeKey: repository accessor getIdleReadWriteClient asMongoUrl.
+	repeats := 1000.
+	repeats
+		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
+			counters
+				at: client asMongoUrl
+				put: (counters at: client asMongoUrl) + 1 ].
+	lowerBound := (repeats / counters size) - (repeats * 0.05).
+	upperBound := (repeats / counters size) + (repeats * 0.05).
+	counters values
+		do: [ :each | 
+			self assert: each > lowerBound.
+			self assert: upperBound > each ]
+]
+
+{ #category : #tests }
 MaplessResourcesTest >> testHalfHalfChance [
 	| wr n1 n2 i j latest |
 	i := 0.

--- a/src/Mapless-Base-Core/MaplessResourcesTest.class.st
+++ b/src/Mapless-Base-Core/MaplessResourcesTest.class.st
@@ -1,0 +1,104 @@
+Class {
+	#name : #MaplessResourcesTest,
+	#superclass : #MaplessTestCase,
+	#instVars : [
+		'repository'
+	],
+	#category : #'Mapless-Base-Core-Tests'
+}
+
+{ #category : #tests }
+MaplessResourcesTest >> test11And44And44Chance [
+	| wr n1 n2 i j latest k n3 |
+	i := 0.
+	j := 0.
+	k := 0.
+	wr := MaplessWeightedRandomPolicy new.
+	n1 := MaplessWeightedNode new
+		weight: 0.5;
+		value: 'url1';
+		yourself.
+	n2 := MaplessWeightedNode new
+		weight: 2;
+		value: 'url2';
+		yourself.
+	n3 := MaplessWeightedNode new
+		weight: 2;
+		value: 'url3';
+		yourself.
+	wr
+		addNode: n1;
+		addNode: n2;
+		addNode: n3;
+		yourself.
+	10000
+		timesRepeat: [ latest := wr next.
+			latest value = 'url1'
+				ifTrue: [ i := i + 1 ].
+			latest value = 'url2'
+				ifTrue: [ j := j + 1 ].
+			latest value = 'url3'
+				ifTrue: [ k := k + 1 ] ].
+	self assert: i > 1000.
+	self assert: i < 1200.
+	self assert: j > 4300.
+	self assert: j < 4500.
+	self assert: k > 4300.
+	self assert: k < 4500
+]
+
+{ #category : #tests }
+MaplessResourcesTest >> test30And70Chance [
+	| wr n1 n2 i j latest |
+	i := 0.
+	j := 0.
+	wr := MaplessWeightedRandomPolicy new.
+	n1 := MaplessWeightedNode new
+		weight: 30;
+		value: 'url1';
+		yourself.
+	n2 := MaplessWeightedNode new
+		weight: 70;
+		value: 'url2';
+		yourself.
+	wr
+		addNode: n1;
+		addNode: n2;
+		yourself.
+	10000
+		timesRepeat: [ latest := wr next.
+			latest value = 'url1'
+				ifTrue: [ i := i + 1 ].
+			latest value = 'url2'
+				ifTrue: [ j := j + 1 ] ].
+	self assert: i > 2900.
+	self assert: j > 6900
+]
+
+{ #category : #tests }
+MaplessResourcesTest >> testHalfHalfChance [
+	| wr n1 n2 i j latest |
+	i := 0.
+	j := 0.
+	wr := MaplessWeightedRandomPolicy new.
+	n1 := MaplessWeightedNode new
+		weight: 2;
+		value: 'url1';
+		yourself.
+	n2 := MaplessWeightedNode new
+		weight: 2;
+		value: 'url2';
+		yourself.
+	wr
+		addNode: n1;
+		addNode: n2;
+		yourself.
+	10000
+		timesRepeat: [ latest := wr next.
+			latest value = 'url1'
+				ifTrue: [ i := i + 1 ].
+			latest value = 'url2'
+				ifTrue: [ j := j + 1 ] ].
+	self assert: i > 4900.
+	self assert: j > 4900
+]

--- a/src/Mapless-Base-Core/MaplessResourcesTest.class.st
+++ b/src/Mapless-Base-Core/MaplessResourcesTest.class.st
@@ -76,39 +76,6 @@ MaplessResourcesTest >> test30And70Chance [
 ]
 
 { #category : #tests }
-MaplessResourcesTest >> testEqualChanceWithoutWeightSpecification [
-	| someMongoUrls counters client repeats lowerBound upperBound |
-	someMongoUrls := {'127.0.0.1:27017' . '127.0.0.1:27019'.
-	'127.0.0.1:27020' . '127.0.0.1:27021' . '127.0.0.1:27022'}.
-	counters := Dictionary new.
-	repository := MaplessMongoRepository
-		for: 'Mapless-Test'
-		with:
-			(MaplessMongoReplicaSetPool
-				mongoUrls: someMongoUrls
-				database: 'Mapless-Test').
-	repository accessor
-		minReadOnlyClients: 10;
-		minReadWriteClients: 10;
-		start.
-	someMongoUrls do: [ :url | counters at: url asMongoUrl put: 0 ].
-	counters
-		removeKey: repository accessor getIdleReadWriteClient asMongoUrl.
-	repeats := 1000.
-	repeats
-		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
-			counters
-				at: client asMongoUrl
-				put: (counters at: client asMongoUrl) + 1 ].
-	lowerBound := (repeats / counters size) - (repeats * 0.05).
-	upperBound := (repeats / counters size) + (repeats * 0.05).
-	counters values
-		do: [ :each | 
-			self assert: each > lowerBound.
-			self assert: upperBound > each ]
-]
-
-{ #category : #tests }
 MaplessResourcesTest >> testHalfHalfChance [
 	| wr n1 n2 i j latest |
 	i := 0.

--- a/src/Mapless-Base-Core/MaplessUnavailableClient.class.st
+++ b/src/Mapless-Base-Core/MaplessUnavailableClient.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MaplessUnavailableClient,
+	#superclass : #MaplessError,
+	#category : #'Mapless-Base-Core-Errors'
+}

--- a/src/Mapless-Base-Core/MaplessWeightedNode.class.st
+++ b/src/Mapless-Base-Core/MaplessWeightedNode.class.st
@@ -1,0 +1,79 @@
+"
+I help to randomly allocate resources with a custom weight that influences their likelyhood to be choosen.
+"
+Class {
+	#name : #MaplessWeightedNode,
+	#superclass : #Object,
+	#instVars : [
+		'weight',
+		'value',
+		'top',
+		'bottom'
+	],
+	#category : #'Mapless-Base-Core-Resources'
+}
+
+{ #category : #accessing }
+MaplessWeightedNode >> bottom [
+	^ bottom
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> bottom: anObject [
+	bottom := anObject
+]
+
+{ #category : #initialization }
+MaplessWeightedNode >> initializeWeight [
+	^ weight := 1
+]
+
+{ #category : #testing }
+MaplessWeightedNode >> matches: aRandomValue [
+	^ aRandomValue > bottom and: [ aRandomValue < top ]
+]
+
+{ #category : #printing }
+MaplessWeightedNode >> printOn: aStream [
+	super printOn: aStream.
+	aStream << ('({1})' format: {value asString})
+]
+
+{ #category : #actions }
+MaplessWeightedNode >> recalculateHeightOnTopOf: aWeightedNodeOrNil [
+	aWeightedNodeOrNil
+		ifNil: [ bottom := 0.
+			top := weight ]
+		ifNotNil: [ bottom := aWeightedNodeOrNil top.
+			top := bottom + weight ]
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> top [
+	^ top
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> top: anObject [
+	top := anObject
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> value [
+	^ value
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> value: anObject [
+	value := anObject
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> weight [
+	^ weight ifNil: [ self initializeWeight ]
+]
+
+{ #category : #accessing }
+MaplessWeightedNode >> weight: anObject [
+	weight := anObject
+]

--- a/src/Mapless-Base-Core/MaplessWeightedNode.class.st
+++ b/src/Mapless-Base-Core/MaplessWeightedNode.class.st
@@ -13,6 +13,14 @@ Class {
 	#category : #'Mapless-Base-Core-Resources'
 }
 
+{ #category : #'instance creation' }
+MaplessWeightedNode class >> weight: aNumber value: aValue [
+	^ self new
+		weight: aNumber;
+		value: aValue;
+		yourself
+]
+
 { #category : #accessing }
 MaplessWeightedNode >> bottom [
 	^ bottom

--- a/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
+++ b/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
@@ -1,0 +1,81 @@
+"
+I help to randomly allocate resources with a custom weight that influences their likelyhood to be choosen.
+"
+Class {
+	#name : #MaplessWeightedRandomPolicy,
+	#superclass : #MaplessResourcePolicy,
+	#instVars : [
+		'nodes',
+		'random',
+		'totalWeight'
+	],
+	#category : #'Mapless-Base-Core-Resources'
+}
+
+{ #category : #'instance creation' }
+MaplessWeightedRandomPolicy class >> new [
+	^ self seed: DateAndTime now asUnixTime
+]
+
+{ #category : #'instance creation' }
+MaplessWeightedRandomPolicy class >> seed: anInteger [
+
+	^ super new initializeOn: anInteger 
+]
+
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> addNode: aNode [
+	self nodes add: aNode.
+	self recalculateWeight.
+	^ aNode
+]
+
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> getNext: aRandomValue [
+	^ self nodes
+		detect: [ :node | node matches: aRandomValue ]
+		ifNone: [ self error: 'Improper weighted resource configuration' ]
+]
+
+{ #category : #initialization }
+MaplessWeightedRandomPolicy >> initializeNodes [
+	^ nodes := OrderedCollection new
+]
+
+{ #category : #initialization }
+MaplessWeightedRandomPolicy >> initializeOn: anInteger [
+	random := Random seed: anInteger.
+	self recalculateWeight 
+]
+
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> next [
+	"Returns the next resource node with a randomn probability that will follow the node's weight"
+
+	^ self getNext: totalWeight * random next
+]
+
+{ #category : #accessing }
+MaplessWeightedRandomPolicy >> nodes [
+	^ nodes ifNil: [ self initializeNodes ]
+]
+
+{ #category : #accessing }
+MaplessWeightedRandomPolicy >> nodes: anObject [
+	nodes := anObject
+]
+
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> recalculateWeight [
+	totalWeight := self nodes
+		inject: 0
+		into: [ :sum :node | sum + node weight ].
+	self nodes ifEmpty: [ ^ self ].
+	self nodes first recalculateHeightOnTopOf: nil.
+	self nodes reduceLeft: [ :a :b | b recalculateHeightOnTopOf: a ]
+]
+
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> removeNode: aNode [
+	^ self nodes remove: aNode ifAbsent: [ nil ]
+]

--- a/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
+++ b/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
@@ -13,6 +13,16 @@ Class {
 }
 
 { #category : #'instance creation' }
+MaplessWeightedRandomPolicy class >> fromDictionary: weights seed: aRandomSeedValue [
+	| newOne |
+	newOne := self seed: aRandomSeedValue.
+	weights
+		keysAndValuesDo:
+			[ :key :value | newOne addNode: (MaplessWeightedNode weight: value value: key) ].
+	^ newOne
+]
+
+{ #category : #'instance creation' }
 MaplessWeightedRandomPolicy class >> new [
 	^ self seed: DateAndTime now asUnixTime
 ]
@@ -55,6 +65,14 @@ MaplessWeightedRandomPolicy >> next [
 	^ self getNext: totalWeight * random next
 ]
 
+{ #category : #actions }
+MaplessWeightedRandomPolicy >> nextAmong: values [
+	| nextOne |
+	[ nextOne isNil or: [ (values includes: nextOne value) not ] ]
+		whileTrue: [ nextOne := self next ].
+	^ nextOne value
+]
+
 { #category : #accessing }
 MaplessWeightedRandomPolicy >> nodes [
 	^ nodes ifNil: [ self initializeNodes ]
@@ -63,6 +81,11 @@ MaplessWeightedRandomPolicy >> nodes [
 { #category : #accessing }
 MaplessWeightedRandomPolicy >> nodes: anObject [
 	nodes := anObject
+]
+
+{ #category : #accessing }
+MaplessWeightedRandomPolicy >> random [
+	^ random
 ]
 
 { #category : #actions }

--- a/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
+++ b/src/Mapless-Base-Core/MaplessWeightedRandomPolicy.class.st
@@ -100,5 +100,13 @@ MaplessWeightedRandomPolicy >> recalculateWeight [
 
 { #category : #actions }
 MaplessWeightedRandomPolicy >> removeNode: aNode [
-	^ self nodes remove: aNode ifAbsent: [ nil ]
+	| target |
+	target := self nodes remove: aNode ifAbsent: [ nil ].
+	self recalculateWeight.
+	^ target
+]
+
+{ #category : #accessing }
+MaplessWeightedRandomPolicy >> totalWeight [
+	^ totalWeight
 ]

--- a/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
+++ b/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
@@ -52,6 +52,24 @@ MaplessMongoReplicaSetPool class >> defaultMinReadWriteClients [
 ]
 
 { #category : #'instance creation' }
+MaplessMongoReplicaSetPool class >> fromString: aStringOfOptionalWeigthsAndMongoUrls database: databaseName [
+	| parts weights mongoUrls url weight |
+	weights := Dictionary new.
+	parts := aStringOfOptionalWeigthsAndMongoUrls substrings: ','.
+	parts := parts collect: [ :each | each substrings: '@' ].
+	parts
+		do: [ :each | 
+			each size > 1
+				ifTrue: [ url := each second.
+					weight := each first asNumber ]
+				ifFalse: [ url := each first.
+					weight := 1 ].
+			weights at: url asMongoUrl put: weight ].
+	mongoUrls := weights keys.
+	^ self mongoUrls: mongoUrls weights: weights database: databaseName
+]
+
+{ #category : #'instance creation' }
 MaplessMongoReplicaSetPool class >> mongoUrls: someMongoUrls database: databaseName [
 	^ self
 		mongoUrls: someMongoUrls asOrderedCollection
@@ -302,6 +320,11 @@ MaplessMongoReplicaSetPool >> initializeMongoUrls: someMongoUrls weights: weight
 		seed: DateAndTime now asUnixTime
 ]
 
+{ #category : #accessing }
+MaplessMongoReplicaSetPool >> loadBalancer [
+	^ loadBalancer
+]
+
 { #category : #actions }
 MaplessMongoReplicaSetPool >> makeClientWith: aMongoUrl [
 	"Answers a new open MongoAPI client or nil if there is a network error."
@@ -380,7 +403,7 @@ MaplessMongoReplicaSetPool >> newTrivialLoadBalancer [
 
 	| weights |
 	weights := [ :dic | 
-	resolver mongoUrls do: [ :url | dic at: url put: 1 ].
+	resolver mongoUrls do: [ :url | dic at: url asMongoUrl put: 1 ].
 	dic ] value: Dictionary new.
 	^ MaplessWeightedRandomPolicy
 		fromDictionary: weights
@@ -396,11 +419,12 @@ MaplessMongoReplicaSetPool >> onNotPrimaryReadWriteAttempt: aBlock using: aMongo
 
 { #category : #reactions }
 MaplessMongoReplicaSetPool >> onPrimaryFound: aMongoAPI [
-
 	self removeInvalidClients.
 	self ensureMinimumQuantityOfReadOnlyClients.
 	self ensureMinimumQuantityOfReadWriteClients.
-	
+	loadBalancer nodes
+		detect: [ :node | node value = resolver getPrimaryMongoUrl ]
+		ifFound: [ :found | loadBalancer removeNode: found ]
 ]
 
 { #category : #actions }

--- a/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
+++ b/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
@@ -17,7 +17,8 @@ Class {
 		'minReadWriteClients',
 		'minReadOnlyClients',
 		'maxReadWriteClients',
-		'maxReadOnlyClients'
+		'maxReadOnlyClients',
+		'loadBalancer'
 	],
 	#category : #'Mapless-Mongo-Core-Connections'
 }
@@ -63,6 +64,27 @@ MaplessMongoReplicaSetPool class >> mongoUrls: someMongoUrls database: databaseN
 MaplessMongoReplicaSetPool class >> mongoUrls: someMongoUrls database: databaseName username: aUserName password: aPassword [
 	^ self basicNew
 		initializeMongoUrls: (someMongoUrls collect: #asMongoUrl)
+			database: databaseName
+			username: aUserName
+			password: aPassword;
+		yourself
+]
+
+{ #category : #'instance creation' }
+MaplessMongoReplicaSetPool class >> mongoUrls: someMongoUrls weights: weightsDictionary database: databaseName [
+	^ self
+		mongoUrls: someMongoUrls
+		weights: weightsDictionary
+		database: databaseName
+		username: ''
+		password: ''
+]
+
+{ #category : #'instance creation' }
+MaplessMongoReplicaSetPool class >> mongoUrls: someMongoUrls weights: weightsDictionary database: databaseName username: aUserName password: aPassword [
+	^ self basicNew
+		initializeMongoUrls: (someMongoUrls collect: #asMongoUrl)
+			weights: weightsDictionary
 			database: databaseName
 			username: aUserName
 			password: aPassword;
@@ -142,6 +164,27 @@ MaplessMongoReplicaSetPool >> getCurrentPrimaryMongoUrl [
 	
 	self mongoUrls
 
+]
+
+{ #category : #actions }
+MaplessMongoReplicaSetPool >> getIdleReadOnlyClient [
+	"Answer the next mongo client among the idle read only one regarding to the load balancer.
+	Or nil that can't be found."
+
+	| idleReadOnlyClientUrls selectedUrl |
+	idleReadOnlyClientUrls := idleReadOnlyClients
+		collect: [ :each | each asMongoUrl ].
+	idleReadOnlyClientUrls ifEmpty: [ ^ nil ].
+	selectedUrl := loadBalancer
+		nextAmong: (Set newFrom: idleReadOnlyClientUrls).
+	^ idleReadOnlyClients
+		detect: [ :e | e asMongoUrl = selectedUrl ]
+		ifNone: [ nil ]
+]
+
+{ #category : #actions }
+MaplessMongoReplicaSetPool >> getIdleReadWriteClient [
+	^ idleReadWriteClients atRandom: loadBalancer random
 ]
 
 { #category : #accessing }
@@ -244,7 +287,19 @@ MaplessMongoReplicaSetPool >> initializeMongoUrls: someMongoUrls database: datab
 	self initialize.
 	username := aUserName.
 	password := aPassword.
-	resolver := MaplessMongoResolver fromMongoUrls: someMongoUrls
+	resolver := MaplessMongoResolver fromMongoUrls: someMongoUrls.
+	loadBalancer := self newTrivialLoadBalancer
+]
+
+{ #category : #initialization }
+MaplessMongoReplicaSetPool >> initializeMongoUrls: someMongoUrls weights: weightsDictionary database: databaseName username: aUserName password: aPassword [
+	self initialize.
+	username := aUserName.
+	password := aPassword.
+	resolver := MaplessMongoResolver fromMongoUrls: someMongoUrls.
+	loadBalancer := MaplessWeightedRandomPolicy
+		fromDictionary: weightsDictionary
+		seed: DateAndTime now asUnixTime
 ]
 
 { #category : #actions }
@@ -316,6 +371,20 @@ MaplessMongoReplicaSetPool >> minReadWriteClients [
 { #category : #accessing }
 MaplessMongoReplicaSetPool >> minReadWriteClients: anObject [
 	minReadWriteClients := anObject
+]
+
+{ #category : #actions }
+MaplessMongoReplicaSetPool >> newTrivialLoadBalancer [
+	"Answers a new load balancer that will have equal chances of 
+	selecting any client (weight 1 for all urls)."
+
+	| weights |
+	weights := [ :dic | 
+	resolver mongoUrls do: [ :url | dic at: url put: 1 ].
+	dic ] value: Dictionary new.
+	^ MaplessWeightedRandomPolicy
+		fromDictionary: weights
+		seed: DateAndTime now asUnixTime
 ]
 
 { #category : #reactions }
@@ -492,7 +561,7 @@ MaplessMongoReplicaSetPool >> requestReadOnlyClient [
 			self hasPrimary
 				ifFalse: [ self findPrimary ].
 			client := self hasIdleReadOnlyClients
-				ifTrue: [ self idleReadOnlyClients anyOne ]
+				ifTrue: [ self getIdleReadOnlyClient ]
 				ifFalse: [ self hasMaxReadOnlyClients
 						ifTrue: [ ^ MaplessMaximumReadWritePoolClientsReached signal ].
 					self makeReadOnlyClient ].
@@ -511,7 +580,7 @@ MaplessMongoReplicaSetPool >> requestReadWriteClient [
 			self hasPrimary
 				ifFalse: [ self findPrimary ].
 			client := self hasIdleReadWriteClients
-				ifTrue: [ self idleReadWriteClients anyOne ]
+				ifTrue: [ self getIdleReadWriteClient ]
 				ifFalse: [ self hasMaxReadWriteClients
 						ifTrue: [ ^ MaplessMaximumReadWritePoolClientsReached signal ].
 					self makeReadWriteClient ].
@@ -545,6 +614,11 @@ MaplessMongoReplicaSetPool >> returnReadWriteClient: aMongoAPIOrNil [
 		critical: [ self busyReadWriteClients remove: aMongoAPIOrNil ifAbsent: [ nil ].
 			(aMongoAPIOrNil isValid and: [ aMongoAPIOrNil isPrimary ])
 				ifTrue: [ self idleReadWriteClients add: aMongoAPIOrNil ] ]
+]
+
+{ #category : #accessing }
+MaplessMongoReplicaSetPool >> secondaryMongoUrls [
+	^ resolver secondaryMongoUrls contents
 ]
 
 { #category : #actions }

--- a/src/Mapless-Mongo-Tests/MaplessMongoResourcesTest.class.st
+++ b/src/Mapless-Mongo-Tests/MaplessMongoResourcesTest.class.st
@@ -1,0 +1,178 @@
+Class {
+	#name : #MaplessMongoResourcesTest,
+	#superclass : #MaplessResourcesTest,
+	#category : #'Mapless-Mongo-Tests-Tests'
+}
+
+{ #category : #tests }
+MaplessMongoResourcesTest >> mongoUrlAsKey: aMongoUrl [
+	^ '{1}:{2}'
+		format:
+			{aMongoUrl host.
+			aMongoUrl port asString}
+]
+
+{ #category : #'setUp-tearDown' }
+MaplessMongoResourcesTest >> setUp [
+	Smalltalk vm maxExternalSemaphoresSilently: 32 * 1024
+]
+
+{ #category : #tests }
+MaplessMongoResourcesTest >> testEqualChanceWithoutWeightSpecification [
+	| someMongoUrls counters client repeats lowerBound upperBound |
+	someMongoUrls := {'127.0.0.1:27017' . '127.0.0.1:27019'.
+	'127.0.0.1:27020' . '127.0.0.1:27021' . '127.0.0.1:27022'}.
+	counters := Dictionary new.
+	repository := MaplessMongoRepository
+		for: 'Mapless-Test'
+		with:
+			(MaplessMongoReplicaSetPool
+				mongoUrls: someMongoUrls
+				database: 'Mapless-Test').
+	repository accessor
+		minReadOnlyClients: 10;
+		minReadWriteClients: 10;
+		start.
+	someMongoUrls do: [ :url | counters at: url asMongoUrl put: 0 ].
+	counters
+		removeKey: repository accessor getIdleReadWriteClient asMongoUrl.
+	repeats := 1000.
+	repeats
+		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
+			counters
+				at: client asMongoUrl
+				put: (counters at: client asMongoUrl) + 1 ].
+	lowerBound := (repeats / counters size) - (repeats * 0.05).
+	upperBound := (repeats / counters size) + (repeats * 0.05).
+	counters values
+		do: [ :each | 
+			self assert: each > lowerBound.
+			self assert: upperBound > each ]
+]
+
+{ #category : #tests }
+MaplessMongoResourcesTest >> testHalf25Half50WeightSpecification [
+	| someMongoUrls counters client repeats lowerBound upperBound mongoUrlString toRemove balancedNodes weight nodeUrl occurrences reference hostAndPort key |
+	mongoUrlString := '25@127.0.0.1:27017,25@127.0.0.1:27019,25@127.0.0.1:27020,50@127.0.0.1:27021,50@127.0.0.1:27022'.
+	counters := Dictionary new.
+	repository := MaplessMongoRepository
+		for: 'Mapless-Test'
+		with:
+			(MaplessMongoReplicaSetPool
+				fromString: mongoUrlString
+				database: 'Mapless-Test').
+	repository accessor
+		minReadOnlyClients: 10;
+		minReadWriteClients: 10;
+		start.
+	someMongoUrls := (mongoUrlString substrings: ',') asOrderedCollection.
+	toRemove := someMongoUrls
+		detect: [ :each | 
+			(each substrings: '@') second asMongoUrl
+				= repository accessor getIdleReadWriteClient asMongoUrl ].
+	someMongoUrls remove: toRemove.
+	someMongoUrls
+		do: [ :url | 
+			hostAndPort := (url substrings: '@') second.
+			counters at: hostAndPort put: 0 ].
+	repeats := 1000.
+	repeats
+		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
+			key := self mongoUrlAsKey: client asMongoUrl.
+			counters at: key put: (counters at: key) + 1 ].
+	balancedNodes := someMongoUrls
+		collect: [ :each | each substrings: '@' ].
+	balancedNodes
+		do: [ :balancedNode | 
+			weight := balancedNode first asNumber.
+			nodeUrl := balancedNode second.
+			occurrences := counters
+				at: (self mongoUrlAsKey: nodeUrl asMongoUrl).
+			reference := weight * repeats
+				/ repository accessor loadBalancer totalWeight.
+			lowerBound := reference - (repeats * 0.03).
+			upperBound := reference + (repeats * 0.03).
+			self assert: occurrences > lowerBound.
+			self assert: upperBound > occurrences ]
+]
+
+{ #category : #tests }
+MaplessMongoResourcesTest >> testMongoUrlWithWeigths [
+	| mongoUrlString someMongoUrls counters repeats client hostAndPort balancedNodes nodeUrl weight toRemove key lowerBound upperBound occurrences reference |
+	mongoUrlString := '33@127.0.0.1:27017,33@127.0.0.1:27019,33@127.0.0.1:27020,80@127.0.0.1:27021,80@127.0.0.1:27022'.
+	repository := MaplessMongoRepository
+		for: 'Mapless-Test'
+		with:
+			(MaplessMongoReplicaSetPool
+				fromString: mongoUrlString
+				database: 'Mapless-Test').
+	repository accessor
+		minReadOnlyClients: 10;
+		minReadWriteClients: 10;
+		start.
+	someMongoUrls := (mongoUrlString substrings: ',') asOrderedCollection.
+	toRemove := someMongoUrls
+		detect: [ :each | 
+			(each substrings: '@') second asMongoUrl
+				= repository accessor getIdleReadWriteClient asMongoUrl ].
+	someMongoUrls remove: toRemove.
+	counters := Dictionary new.
+	someMongoUrls
+		do: [ :url | 
+			hostAndPort := (url substrings: '@') second.
+			counters at: hostAndPort put: 0 ].
+	toRemove := repository accessor getIdleReadWriteClient asMongoUrl.
+	toRemove := self mongoUrlAsKey: toRemove.
+	repeats := 1000.
+	repeats
+		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
+			key := self mongoUrlAsKey: client asMongoUrl.
+			counters at: key put: (counters at: key) + 1 ].
+	balancedNodes := someMongoUrls
+		collect: [ :each | each substrings: '@' ].
+	balancedNodes
+		do: [ :balancedNode | 
+			weight := balancedNode first asNumber.
+			nodeUrl := balancedNode second.
+			occurrences := counters
+				at: (self mongoUrlAsKey: nodeUrl asMongoUrl).
+			reference := weight * repeats
+				/ repository accessor loadBalancer totalWeight.
+			lowerBound := reference - (repeats * 0.03).
+			upperBound := reference + (repeats * 0.03).
+			self assert: occurrences > lowerBound.
+			self assert: upperBound > occurrences ]
+]
+
+{ #category : #tests }
+MaplessMongoResourcesTest >> testMongoUrlWithoutWeigths [
+	| mongoUrlString repeats client counters lowerBound upperBound someMongoUrls |
+	mongoUrlString := '127.0.0.1:27017,127.0.0.1:27019,127.0.0.1:27020,127.0.0.1:27021,127.0.0.1:27022'.
+	counters := Dictionary new.
+	repository := MaplessMongoRepository
+		for: 'Mapless-Test'
+		with:
+			(MaplessMongoReplicaSetPool
+				fromString: mongoUrlString
+				database: 'Mapless-Test').
+	repository accessor
+		minReadOnlyClients: 10;
+		minReadWriteClients: 10;
+		start.
+	someMongoUrls := mongoUrlString substrings: ','.
+	someMongoUrls do: [ :url | counters at: url asMongoUrl put: 0 ].
+	counters
+		removeKey: repository accessor getIdleReadWriteClient asMongoUrl.
+	repeats := 1000.
+	repeats
+		timesRepeat: [ client := repository accessor getIdleReadOnlyClient.
+			counters
+				at: client asMongoUrl
+				put: (counters at: client asMongoUrl) + 1 ].
+	lowerBound := repeats / counters size - (repeats * 0.05).
+	upperBound := repeats / counters size + (repeats * 0.05).
+	counters values
+		do: [ :each | 
+			self assert: each > lowerBound.
+			self assert: upperBound > each ]
+]


### PR DESCRIPTION
Adds a `loadBalancer` to `MaplessMongoReplicaSetPool` which is implemented with the newly introduced `MaplessWeightedRandomPolicy`.

In addition to the existing ones, `MaplessMongoReplicaSetPool` can now be instantiated using the new instance creation methods:
- `mongoUrls: someMongoUrls weights: weightsDictionary database: databaseName username: aUserName password: aPassword`
- `mongoUrls: someMongoUrls weights: weightsDictionary database: databaseName` and
- `fromString: aStringOfOptionalWeigthsAndMongoUrls database: databaseName`

For example `testMongoUrlWithoutWeigths` will use omission for how much weight to consider when load balancing read-only clients idle in the pool. In the other hand `testHalf25Half50WeightSpecification` will use an asymmetric configuration of 25 for two nodes and 50 for the other two: `25@127.0.0.1:27019,25@127.0.0.1:27020,50@127.0.0.1:27021,50@127.0.0.1:27022`.

These unit tests will require to use a real local replica set of 5 nodes.