### PR TITLE
fixes SQLite remove client and adds coverage testRemoveClient

### DIFF
--- a/src/Mapless-SQLite-Tests/MaplessSQLiteTest.class.st
+++ b/src/Mapless-SQLite-Tests/MaplessSQLiteTest.class.st
@@ -349,6 +349,18 @@ MaplessSQLiteTest >> testDestroy [
 ]
 
 { #category : #tests }
+MaplessSQLiteTest >> testDisconnect [
+
+	repository withClientDo: [ :client |
+		self assert: client isValid.
+		client close.
+		self deny: client isValid ].
+
+	repository withClientDo: [ :client |
+		self assert: client getTableNames notEmpty ]
+]
+
+{ #category : #tests }
 MaplessSQLiteTest >> testExists [
 	| guy loaded |
 	guy := SamplePerson new
@@ -538,6 +550,16 @@ MaplessSQLiteTest >> testQueryUsers [
 				  findOne: SampleUser
 				  where: ('json_extract(maplessData,"$.username") = {1}' format:
 						   { char asString printString })) notNil ])
+]
+
+{ #category : #tests }
+MaplessSQLiteTest >> testRemoveClient [
+
+	repository withClientDo: [ :client |
+		repository accessor remove: client ].
+
+	repository withClientDo: [ :client |
+		self assert: client getTableNames notEmpty ]
 ]
 
 { #category : #tests }

--- a/src/Mapless-SQLite/MaplessSQLitePool.class.st
+++ b/src/Mapless-SQLite/MaplessSQLitePool.class.st
@@ -171,7 +171,7 @@ MaplessSQLitePool >> quantityOfClients [
 
 { #category : #actions }
 MaplessSQLitePool >> remove: aMaplessDbClient [
-	aMaplessDbClient disconnect.
+	aMaplessDbClient close.
 	self idleClients remove: aMaplessDbClient ifAbsent: [ nil ].
 	self busyClients remove: aMaplessDbClient ifAbsent: [ nil ]
 ]


### PR DESCRIPTION
In the SQLite pool, the `remove: aSQLiteClient`  method was using `disconnect` instead of `close`. 

This fixes that and adds 2 unit tests for coverage on this